### PR TITLE
iOS eventIdentifier property

### DIFF
--- a/RNCalendarEvents.m
+++ b/RNCalendarEvents.m
@@ -8,6 +8,7 @@
 @end
 
 static NSString *const _id = @"id";
+static NSString *const _eventIdentifier = @"eventIdentifier";
 static NSString *const _calendarId = @"calendarId";
 static NSString *const _title = @"title";
 static NSString *const _location = @"location";
@@ -469,6 +470,7 @@ RCT_EXPORT_MODULE()
 {
 
     NSDictionary *emptyCalendarEvent = @{
+                                         _eventIdentifier: @"",
                                          _title: @"",
                                          _location: @"",
                                          _startDate: @"",
@@ -511,6 +513,10 @@ RCT_EXPORT_MODULE()
                                         @"color": [self hexStringFromColor:[UIColor colorWithCGColor:event.calendar.CGColor]]
                                         }
                                forKey:@"calendar"];
+    }
+
+    if (event.eventIdentifier) {
+      [formedCalendarEvent setValue:event.eventIdentifier forKey:_eventIdentifier];
     }
 
     if (event.title) {

--- a/index.d.ts
+++ b/index.d.ts
@@ -100,6 +100,8 @@ interface CalendarEventBase {
 export interface CalendarEventReadable extends CalendarEventBase {
   /** Unique id for the calendar event */
   id: string;
+  /** iOS ONLY - iOS's own unique identifier for calendar events */
+  eventIdentifier?: string;
   /** The title for the calendar event. */
   title: string;
   /** The attendees of the event, including the organizer. */


### PR DESCRIPTION
Add `eventIdentifier` property for iOS events. This identifier is used to show and edit existing iOS calendar events.